### PR TITLE
Remove upper bound on pandas

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - lmoments3 >=1.0.5
     - numba
     - numpy >=1.16
-    - pandas >=0.23,<2.0  # Temporarily pinned due to incompatibilities with xarray
+    - pandas >=0.23
     - pint >=0.10
     - pyyaml
     - scikit-learn >=0.21.3


### PR DESCRIPTION
https://docs.xarray.dev/en/stable/whats-new.html#v2023-04-0-april-14-2023 notes that xarray `v2023.04.0` is now compatible with pandas 2.0